### PR TITLE
Changed scene_system to allow for indirect access using string names of scenes.

### DIFF
--- a/src/main/java/characters/CharacterInventoryFacade.java
+++ b/src/main/java/characters/CharacterInventoryFacade.java
@@ -92,4 +92,11 @@ public class CharacterInventoryFacade implements ItemCheckable {
         return inventory.checkItem(itemName);
     }
 
+    /**
+     * Gets the string of the character's name.
+     * @return a string of the character's name.
+     */
+    public String getName(){
+        return this.character.getName();
+    }
 }

--- a/src/main/java/characters/CharacterManager.java
+++ b/src/main/java/characters/CharacterManager.java
@@ -110,6 +110,10 @@ public class CharacterManager {
         }
 
     }
+
+    public String getName(){
+        return this.character.getName();
+    }
 }
 //    public Object getNpcs() {
 //        return new JSONObject(this.npcs);

--- a/src/main/java/characters/CharacterManager.java
+++ b/src/main/java/characters/CharacterManager.java
@@ -110,7 +110,11 @@ public class CharacterManager {
         }
 
     }
-
+    
+   /**
+    * Returns the name of the character.
+    * @return the string representing the name of the character.
+    */
     public String getName(){
         return this.character.getName();
     }

--- a/src/main/java/scene_system/Scene.java
+++ b/src/main/java/scene_system/Scene.java
@@ -9,6 +9,7 @@ import items.Item;
 import characters.PlayerCharacter;
 import combat_system.Combat;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -118,6 +119,30 @@ public class Scene {
             this.combat = new Combat(participants, this.observers);
         }
         return this.combat;
+    }
+
+    /**
+     * Gets a list of the names of all connected areas.
+     * @return the array list containing the string names of all connected scenes to this one.
+     */
+    public ArrayList<String> getConnectedAreaNames() {
+        ArrayList<String> areaNames = new ArrayList<>();
+        for(Scene sc : connectedAreas) {
+            areaNames.add(sc.getName());
+        }
+        return areaNames;
+    }
+
+    /**
+     * Gets a list of the names of all npcs in the scene.
+     * @return an array list containing the names of all npcs in the scene.
+     */
+    public ArrayList<String> getNpcNames() {
+        ArrayList<String> npcNames = new ArrayList<>();
+        for(CharacterInventoryFacade nonPlayer : npc) {
+            npcNames.add(nonPlayer.getName());
+        }
+        return npcNames;
     }
 }
 

--- a/src/main/java/scene_system/SceneManager.java
+++ b/src/main/java/scene_system/SceneManager.java
@@ -1,11 +1,24 @@
 package scene_system;
 
+import characters.CharacterInventoryFacade;
 import scene_system.Scene;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Handles modifications and accessing of information from scene classes, and stores a hashmap
+ * of the scenes in the game, that can be referenced by their names in string form.
+ */
 public class SceneManager {
 
+    private HashMap<String, Scene> sceneList;
 
     public SceneManager(){}
+
+    public SceneManager(HashMap<String, Scene> scenes){
+        this.sceneList = scenes;
+    }
 
     /**
      * Return the description of the scene
@@ -14,5 +27,41 @@ public class SceneManager {
      */
     public String displayScene(Scene scene) {
         return scene.getDescription();
+    }
+
+    /**
+     * Returns the description of the scene
+     * @param sceneName the string containing the name of the scene.
+     * @return the description of the scene to be displayed.
+     */
+    public String displayScene(String sceneName) {
+        return this.sceneList.get(sceneName).getDescription();
+    }
+
+    /**
+     * Returns an array list containing the connected areas to the given scene.
+     * @param sceneName The name of the scene you are looking for the connecting areas of in String form.
+     * @return the ArrayList containing the string names of all connected areas to the given scene.
+     */
+    public ArrayList<String> getTravelOptions(String sceneName){
+        return this.sceneList.get(sceneName).getConnectedAreaNames();
+    }
+
+    /**
+     * Gets a list of names of all the npcs in the given scene.
+     * @param sceneName The name of the scene you are concerned with in String form.
+     * @return an ArrayList containing the string names of all npcs in the area.
+     */
+    public ArrayList<String> getNpcNames(String sceneName){
+        return this.sceneList.get(sceneName).getNpcNames();
+    }
+
+    /**
+     * Gets a list of the facade classes of npcs in the given scene.
+     * @param sceneName The name of the scene you are concerned with in String form.
+     * @return an ArrayList containing the facades of the npcs in the scene.
+     */
+    public ArrayList<CharacterInventoryFacade> getNPC(String sceneName){
+        return this.sceneList.get(sceneName).getNpc();
     }
 }


### PR DESCRIPTION
Changed SceneManager and Scene to be able to be referenced and accessed through the string of a scene's name, instead of accessing the scene directly. Also added a getName to CharacterInventoryFacade and CharacterManager to allow the possibility of doing this for characters as well.